### PR TITLE
Fix update notifications never reaching installed sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**#### 2.0.9 2026-08-05**
+
+- [FIXED] Update notifications never appeared. `shazzad/github-plugin-updater` treated the optional `tested`, `requires` and `requires_php` fields as mandatory, so releases without them were silently discarded and no site was ever offered an update.
+- [UPDATED] Bumped `shazzad/github-plugin-updater` to the release carrying that fix.
+- [UPDATED] README requirements list uses `*` bullets so older installs running the unpatched updater can also resolve the metadata.
+
 **#### 2.0.1 2025-05-04**
 
 - [IMPROVEMENT] Trim request url before storing in database

--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ All logs can be viewed at `Wp Admin > Logs` page.
 
 ### Requirements
 
-- WordPress: 5.0
-- PHP: 7.4
-- Tested: 6.8.1
+* WordPress: 5.0
+* PHP: 7.4
+* Tested: 6.8.1

--- a/composer.lock
+++ b/composer.lock
@@ -112,12 +112,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/shazzad/github-plugin-updater.git",
-                "reference": "63c5637c84242036b43775110da5f82e56b657aa"
+                "reference": "8c66ef8da3898b2ba481c16d6ac8bfcc3a1d94fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shazzad/github-plugin-updater/zipball/63c5637c84242036b43775110da5f82e56b657aa",
-                "reference": "63c5637c84242036b43775110da5f82e56b657aa",
+                "url": "https://api.github.com/repos/shazzad/github-plugin-updater/zipball/8c66ef8da3898b2ba481c16d6ac8bfcc3a1d94fe",
+                "reference": "8c66ef8da3898b2ba481c16d6ac8bfcc3a1d94fe",
                 "shasum": ""
             },
             "require": {
@@ -131,12 +131,15 @@
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
             "description": "Helper library to implement wordpress plugin update from github repo.",
             "support": {
                 "issues": "https://github.com/shazzad/github-plugin-updater/issues",
                 "source": "https://github.com/shazzad/github-plugin-updater/tree/main"
             },
-            "time": "2022-09-18T00:09:41+00:00"
+            "time": "2026-08-04T23:02:09+00:00"
         }
     ],
     "packages-dev": [
@@ -331,7 +334,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "shazzad-wp-logs",
-	"version": "2.0.8",
+	"version": "2.0.9",
 	"private": true,
 	"scripts": {
 		"build": "grunt build",

--- a/shazzad-wp-logs.php
+++ b/shazzad-wp-logs.php
@@ -3,7 +3,7 @@
  * Plugin Name: Shazzad Wp Logs
  * Plugin URI: https://w4dev.com
  * Description: Store and view logs for debugging.
- * Version: 2.0.8
+ * Version: 2.0.9
  * Requires at least: 4.4.0
  * Requires PHP: 7.4
  * Author: Shazzad Hossain Khan
@@ -24,7 +24,7 @@ if ( defined( 'SWPL_PLUGIN_FILE' ) ) {
 	return;
 }
 
-define( 'SWPL_VERSION', '2.0.8' );
+define( 'SWPL_VERSION', '2.0.9' );
 define( 'SWPL_PLUGIN_FILE', __FILE__ );
 define( 'SWPL_DIR', plugin_dir_path( SWPL_PLUGIN_FILE ) );
 define( 'SWPL_URL', plugin_dir_url( SWPL_PLUGIN_FILE ) );


### PR DESCRIPTION
## Summary

- 2.0.8 has been on GitHub since February and **no install has ever been offered it**. The bundled `shazzad/github-plugin-updater` gated updates behind `count( array_filter( $data ) ) > 5`, making the optional `tested` / `requires` / `requires_php` fields mandatory. A release without them scored exactly 5, `Release::available()` returned false, and `pre_set_site_transient_update_plugins` was left untouched — silently, with nothing logged.
- Bumps `shazzad/github-plugin-updater` to `8c66ef8` ([shazzad/github-plugin-updater#5](https://github.com/shazzad/github-plugin-updater/pull/5)), which checks only `version` + `download_url`, accepts `-` and `+` README list markers alongside `*`, and logs when metadata cannot be resolved.
- Switches the README `Requirements` bullets from `-` to `*`. The unpatched updater only strips `*` markers, so this is what lets **existing 2.0.x installs** parse the metadata and finally see a release. Sites still running the old library need this; sites on 2.0.9 don't care either way.
- Bumps version to 2.0.9.

## Test plan

- [x] 13 assertions against the patched library on PHP 8.3 — `available()` across four release shapes, release-body parsing, README parsing with `-` / `*` bullets, CRLF input, heading boundaries, and the real `README.md`. All pass.
- [x] End-to-end A/B on the w4dev dev site against the live 2.0.4 install, changing only the library:
  - old library → `shazzad-wp-logs,2.0.4,none,`
  - new library → `shazzad-wp-logs,2.0.4,available,2.0.8`
- [ ] After release: confirm a stale install (e.g. `guesty-docker`, 2.0.4) is offered 2.0.9 and updates cleanly.

## Release note requirement

The 2.0.9 release body **must** carry these three lines so installs still running the unpatched library clear the old `> 5` gate:

```
Requires: 5.0
Requires Php: 7.4
Tested up to: 6.8.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)