### PR TITLE
Fix update notice persisting after a successful update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**#### 2.0.10 2026-08-05**
+
+- [FIXED] The update notice kept showing "You have version X installed. Update to X." after a successful update, until the next full update check.
+- [UPDATED] `shazzad/github-plugin-updater` to 0.0.5, and pinned it to a tagged release instead of tracking `dev-main`.
+
 **#### 2.0.9 2026-08-05**
 
 - [FIXED] Update notifications never appeared. `shazzad/github-plugin-updater` treated the optional `tested`, `requires` and `requires_php` fields as mandatory, so releases without them were silently discarded and no site was ever offered an update.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"mustache/mustache": "^2.12",
-		"shazzad/github-plugin-updater": "dev-main"
+		"shazzad/github-plugin-updater": "^0.0.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8bd362bbcccfbf920c7055ed03b9e49",
+    "content-hash": "bef38de504c4b031dfabf91cfac0c87e",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -108,22 +108,21 @@
         },
         {
             "name": "shazzad/github-plugin-updater",
-            "version": "dev-main",
+            "version": "0.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shazzad/github-plugin-updater.git",
-                "reference": "8c66ef8da3898b2ba481c16d6ac8bfcc3a1d94fe"
+                "reference": "6c7d0fa1a372a5517b6e417eda8dc344a80dcca6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shazzad/github-plugin-updater/zipball/8c66ef8da3898b2ba481c16d6ac8bfcc3a1d94fe",
-                "reference": "8c66ef8da3898b2ba481c16d6ac8bfcc3a1d94fe",
+                "url": "https://api.github.com/repos/shazzad/github-plugin-updater/zipball/6c7d0fa1a372a5517b6e417eda8dc344a80dcca6",
+                "reference": "6c7d0fa1a372a5517b6e417eda8dc344a80dcca6",
                 "shasum": ""
             },
             "require": {
                 "erusev/parsedown": "^1.7"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -137,9 +136,9 @@
             "description": "Helper library to implement wordpress plugin update from github repo.",
             "support": {
                 "issues": "https://github.com/shazzad/github-plugin-updater/issues",
-                "source": "https://github.com/shazzad/github-plugin-updater/tree/main"
+                "source": "https://github.com/shazzad/github-plugin-updater/tree/0.0.5"
             },
-            "time": "2026-08-04T23:02:09+00:00"
+            "time": "2026-08-04T23:48:22+00:00"
         }
     ],
     "packages-dev": [
@@ -329,9 +328,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "shazzad/github-plugin-updater": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "shazzad-wp-logs",
-	"version": "2.0.9",
+	"version": "2.0.10",
 	"private": true,
 	"scripts": {
 		"build": "grunt build",

--- a/shazzad-wp-logs.php
+++ b/shazzad-wp-logs.php
@@ -3,7 +3,7 @@
  * Plugin Name: Shazzad Wp Logs
  * Plugin URI: https://w4dev.com
  * Description: Store and view logs for debugging.
- * Version: 2.0.9
+ * Version: 2.0.10
  * Requires at least: 4.4.0
  * Requires PHP: 7.4
  * Author: Shazzad Hossain Khan
@@ -24,7 +24,7 @@ if ( defined( 'SWPL_PLUGIN_FILE' ) ) {
 	return;
 }
 
-define( 'SWPL_VERSION', '2.0.9' );
+define( 'SWPL_VERSION', '2.0.10' );
 define( 'SWPL_PLUGIN_FILE', __FILE__ );
 define( 'SWPL_DIR', plugin_dir_path( SWPL_PLUGIN_FILE ) );
 define( 'SWPL_URL', plugin_dir_url( SWPL_PLUGIN_FILE ) );


### PR DESCRIPTION
## Summary

After updating, WordPress kept showing **"You have version 2.0.9 installed. Update to 2.0.9."** with an automatic update scheduled, until the next full update check.

Two causes in `shazzad/github-plugin-updater`, both fixed in [0.0.5](https://github.com/shazzad/github-plugin-updater/releases/tag/0.0.5) ([PR #6](https://github.com/shazzad/github-plugin-updater/pull/6)):

1. `transient_update_plugins()` only added entries, never removed them. `response[]` renders the nag, and an entry written before the update survived into the no-update branch. Each branch now clears the opposite collection.
2. An admin-initiated update replaces the files and rebuilds the transient in one request, but the memoised plugin header and the cached release payload still described the pre-update version — so the updater compared the new release against the *old* version and re-armed the nag. A new `upgrader_process_complete` handler drops both.

Also **pins the dependency to `^0.0.5`** instead of `dev-main`. The lock file already froze the exact ref for release builds, but `dev-main` meant the next `composer update` would silently pull whatever happened to be on the branch.

## Test plan

- [x] A/B on a live install with 2.0.9 on disk, simulating the admin update path:
  - shipped library → `response=2.0.9`, **nag shown**
  - 0.0.5 → `response=-`, `no_update=2.0.9`, no nag
- [x] Stale `response` entry with plugin already at latest → removed, `no_update` set
- [x] Header forced to 2.0.4 → `response` still set to 2.0.9 and the stale `no_update` entry removed, so real updates are unaffected
- [x] `upgrader_process_complete` confirmed registered on the live instance
- [ ] After release: update the dev site 2.0.9 → 2.0.10 through the admin UI and confirm the notice clears immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)